### PR TITLE
Bump versions to fix vuln in jackson-databind

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,13 +21,13 @@ libraryDependencies ++= Seq(
   cacheApi,
   javaWs,
   filters,
-  "net.logstash.logback" % "logstash-logback-encoder" % "5.0",
+  "net.logstash.logback" % "logstash-logback-encoder" % "5.1",
   "org.flywaydb" %% "flyway-play" % "4.0.0",
   "org.postgresql" % "postgresql" % "42.1.4",
   "org.jdbi" % "jdbi" % "2.78",
   "org.apache.commons" % "commons-collections4" % "4.1",
-  "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.264",
-  "com.amazonaws" % "aws-java-sdk-sns" % "1.11.257",
+  "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.385",
+  "com.amazonaws" % "aws-java-sdk-sns" % "1.11.382",
   // We need this dependency to use JDBI @BindIn annotation
   "org.antlr" % "stringtemplate" % "3.2.1",
   "org.jsoup" % "jsoup" % "1.11.2"


### PR DESCRIPTION
This fixes vulnerabilties jackson-databind introduced by sqs, sns and logstash libraries 